### PR TITLE
Support for additional .exd variant

### DIFF
--- a/Godbert/Controls/ColumnFactory.cs
+++ b/Godbert/Controls/ColumnFactory.cs
@@ -22,19 +22,21 @@ namespace Godbert.Controls {
             var header = BuildHeader(column);
             var binding = CreateCellBinding(column);
 
-            DataGridColumn target;
-            if (typeof(SaintCoinach.Imaging.ImageFile).IsAssignableFrom(targetType))
-                target = new RawDataGridImageColumn(column) {
-                    Binding = binding,
-                };
-            else if (typeof(System.Drawing.Color).IsAssignableFrom(targetType))
-                target = new RawDataGridColorColumn(column) {
-                    Binding = binding
-                };
-            else
-                target = new RawDataGridTextColumn(column) {
-                    Binding = binding
-                };
+            DataGridColumn target = null;
+            if (column.Header.Variant == 1) {
+                if (typeof(SaintCoinach.Imaging.ImageFile).IsAssignableFrom(targetType))
+                    target = new RawDataGridImageColumn(column) {
+                        Binding = binding,
+                    };
+                else if (typeof(System.Drawing.Color).IsAssignableFrom(targetType))
+                    target = new RawDataGridColorColumn(column) {
+                        Binding = binding
+                    };
+            }
+
+            target = target ?? new RawDataGridTextColumn(column) {
+                Binding = binding
+            };
 
             target.Header = header;
             target.IsReadOnly = true;
@@ -76,7 +78,21 @@ namespace Godbert.Controls {
                     return null;
 
                 var i = System.Convert.ToInt32(parameter);
-                return row[i];
+                var v = row[i];
+                var d = v as IDictionary<int, object>;
+                if (d != null) {
+                    var sb = new StringBuilder();
+                    var isFirst = true;
+                    foreach (var kvp in d) {
+                        if (isFirst)
+                            isFirst = false;
+                        else
+                            sb.AppendLine();
+                        sb.AppendFormat("[{0},{1}]", kvp.Key, kvp.Value);
+                    }
+                    return sb.ToString();
+                }
+                return v;
             }
 
             public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {

--- a/Godbert/Controls/RawDataGrid.cs
+++ b/Godbert/Controls/RawDataGrid.cs
@@ -82,8 +82,8 @@ namespace Godbert.Controls {
                     continue;
 
                 var dictObj = cellObj as IDictionary<int, object>;
-                if (dictObj != null)
-                    return dictObj.Values.Any(v => v.ToString().IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0);
+                if (dictObj != null && dictObj.Values.Any(v => v.ToString().IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0))
+                    return true;
                 if (cellObj.ToString().IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0)
                     return true;
             }

--- a/Godbert/Controls/RawDataGrid.cs
+++ b/Godbert/Controls/RawDataGrid.cs
@@ -81,6 +81,9 @@ namespace Godbert.Controls {
                 if (cellObj == null)
                     continue;
 
+                var dictObj = cellObj as IDictionary<int, object>;
+                if (dictObj != null)
+                    return dictObj.Values.Any(v => v.ToString().IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0);
                 if (cellObj.ToString().IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0)
                     return true;
             }

--- a/Godbert/ViewModels/DataViewModel.cs
+++ b/Godbert/ViewModels/DataViewModel.cs
@@ -130,6 +130,8 @@ namespace Godbert.ViewModels {
 
                         if (v == null)
                             s.Write(",");
+                        else if (v is IDictionary<int, object>)
+                            WriteDict(s, v as IDictionary<int, object>);
                         else if (IsUnescaped(v))
                             s.Write(",{0}", v);
                         else
@@ -138,6 +140,21 @@ namespace Godbert.ViewModels {
                     s.WriteLine();
                 }
             }
+        }
+        static void WriteDict(StreamWriter s, IDictionary<int, object> v) {
+            s.Write(",\"");
+            var isFirst = true;
+            foreach (var kvp in v) {
+                if (isFirst)
+                    isFirst = false;
+                else
+                    s.Write(",");
+                s.Write("[{0},", kvp.Key);
+                if (kvp.Value != null)
+                    s.Write(kvp.Value.ToString().Replace("\"", "\"\""));
+                s.Write("]");
+            }
+            s.Write("\"");
         }
         static bool IsUnescaped(object self) {
             return (self is Boolean

--- a/SaintCoinach.Cmd/Commands/AllExdCommand.cs
+++ b/SaintCoinach.Cmd/Commands/AllExdCommand.cs
@@ -81,47 +81,8 @@ namespace SaintCoinach.Cmd.Commands {
                 s.WriteLine(nameLine);
                 s.WriteLine(typeLine);
 
-                foreach (var row in sheet.Cast<Ex.IRow>().OrderBy(_ => _.Key)) {
-                    var useRow = row;
-
-                    if (useRow is IXivRow)
-                        useRow = ((IXivRow)row).SourceRow;
-                    var multiRow = useRow as IMultiRow;
-
-                    s.Write(useRow.Key);
-                    foreach (var col in colIndices) {
-                        object v;
-
-                        if (language == Language.None || multiRow == null)
-                            v = useRow[col];
-                        else
-                            v = multiRow[col, language];
-
-                        if (v == null)
-                            s.Write(",");
-                        else if (IsUnescaped(v))
-                            s.Write(",{0}", v);
-                        else
-                            s.Write(",\"{0}\"", v.ToString().Replace("\"", "\"\""));
-                    }
-                    s.WriteLine();
-
-                    s.Flush();
-                }
+                ExdHelper.WriteRows(s, sheet, language, colIndices);
             }
-        }
-        private static bool IsUnescaped(object self) {
-            return (self is Boolean
-                || self is Byte
-                || self is SByte
-                || self is Int16
-                || self is Int32
-                || self is Int64
-                || self is UInt16
-                || self is UInt32
-                || self is UInt64
-                || self is Single
-                || self is Double);
         }
     }
 }

--- a/SaintCoinach.Cmd/Commands/ExdCommand.cs
+++ b/SaintCoinach.Cmd/Commands/ExdCommand.cs
@@ -71,36 +71,8 @@ namespace SaintCoinach.Cmd.Commands {
                 s.WriteLine(nameLine);
                 s.WriteLine(typeLine);
 
-                foreach (var row in sheet.Cast<Ex.IRow>().OrderBy(_ => _.Key)) {
-                    s.Write(row.Key);
-                    foreach (var col in colIndices) {
-                        var v = row[col];
-
-                        if (v == null)
-                            s.Write(",");
-                        else if (IsUnescaped(v))
-                            s.Write(",{0}", v);
-                        else
-                            s.Write(",\"{0}\"", v.ToString().Replace("\"", "\"\""));
-                    }
-                    s.WriteLine();
-
-                    s.Flush();
-                }
+                ExdHelper.WriteRows(s, sheet, Ex.Language.None, colIndices);
             }
-        }
-        private static bool IsUnescaped(object self) {
-            return (self is Boolean
-                || self is Byte
-                || self is SByte
-                || self is Int16
-                || self is Int32
-                || self is Int64
-                || self is UInt16
-                || self is UInt32
-                || self is UInt64
-                || self is Single
-                || self is Double);
         }
     }
 }

--- a/SaintCoinach.Cmd/Commands/RawExdCommand.cs
+++ b/SaintCoinach.Cmd/Commands/RawExdCommand.cs
@@ -71,34 +71,8 @@ namespace SaintCoinach.Cmd.Commands {
                 s.WriteLine(nameLine);
                 s.WriteLine(typeLine);
 
-                foreach (var row in sheet.Cast<Ex.IRow>().OrderBy(_ => _.Key)) {
-                    s.Write(row.Key);
-                    foreach (var col in colIndices) {
-                        var v = row.GetRaw(col);
-
-                        if (v == null)
-                            s.Write(",");
-                        else if (IsUnescaped(v))
-                            s.Write(",{0}", v);
-                        else
-                            s.Write(",\"{0}\"", v.ToString().Replace("\"", "\"\""));
-                    }
-                    s.WriteLine();
-                }
+                ExdHelper.WriteRows(s, sheet, Ex.Language.None, colIndices);
             }
-        }
-        private static bool IsUnescaped(object self) {
-            return (self is Boolean
-                || self is Byte
-                || self is SByte
-                || self is Int16
-                || self is Int32
-                || self is Int64
-                || self is UInt16
-                || self is UInt32
-                || self is UInt64
-                || self is Single
-                || self is Double);
         }
     }
 }

--- a/SaintCoinach.Cmd/ExdHelper.cs
+++ b/SaintCoinach.Cmd/ExdHelper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SaintCoinach.Cmd {
+    using Ex;
+    using Xiv;
+
+    static class ExdHelper {
+        public static void WriteRows(StreamWriter s, ISheet sheet, Language language, IEnumerable<int> colIndices) {
+            foreach (var row in sheet.Cast<Ex.IRow>().OrderBy(_ => _.Key)) {
+                var useRow = row;
+
+                if (useRow is IXivRow)
+                    useRow = ((IXivRow)row).SourceRow;
+                var multiRow = useRow as IMultiRow;
+
+                s.Write(useRow.Key);
+                foreach (var col in colIndices) {
+                    object v;
+
+                    if (language == Language.None || multiRow == null)
+                        v = useRow[col];
+                    else
+                        v = multiRow[col, language];
+
+                    if (v == null)
+                        s.Write(",");
+                    else if (v is IDictionary<int, object>)
+                        WriteDict(s, v as IDictionary<int, object>);
+                    else if (IsUnescaped(v))
+                        s.Write(",{0}", v);
+                    else
+                        s.Write(",\"{0}\"", v.ToString().Replace("\"", "\"\""));
+                }
+                s.WriteLine();
+
+                s.Flush();
+            }
+        }
+        static void WriteDict(StreamWriter s, IDictionary<int, object> v) {
+            s.Write(",\"");
+            var isFirst = true;
+            foreach (var kvp in v) {
+                if (isFirst)
+                    isFirst = false;
+                else
+                    s.Write(",");
+                s.Write("[{0},", kvp.Key);
+                if (kvp.Value != null)
+                    s.Write(kvp.Value.ToString().Replace("\"", "\"\""));
+                s.Write("]");
+            }
+            s.Write("\"");
+        }
+        static bool IsUnescaped(object self) {
+            return (self is Boolean
+                || self is Byte
+                || self is SByte
+                || self is Int16
+                || self is Int32
+                || self is Int64
+                || self is UInt16
+                || self is UInt32
+                || self is UInt64
+                || self is Single
+                || self is Double);
+        }
+    }
+}

--- a/SaintCoinach.Cmd/SaintCoinach.Cmd.csproj
+++ b/SaintCoinach.Cmd/SaintCoinach.Cmd.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Commands\ImageCommand.cs" />
     <Compile Include="Commands\MapCommand.cs" />
     <Compile Include="Commands\RawExdCommand.cs" />
+    <Compile Include="ExdHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/SaintCoinach/Ex/Column.cs
+++ b/SaintCoinach/Ex/Column.cs
@@ -82,6 +82,10 @@
             return ReadRaw(buffer, row);
         }
 
+        public virtual object Read(byte[] buffer, IDataRow row, int offset) {
+            return ReadRaw(buffer, row, offset);
+        }
+
         /// <summary>
         ///     Read the raw column's value in a row.
         /// </summary>
@@ -91,6 +95,11 @@
         public object ReadRaw(byte[] buffer, IDataRow row) {
             return Reader.Read(buffer, this, row);
         }
+
+        public object ReadRaw(byte[] buffer, IDataRow row, int offset) {
+            return Reader.Read(buffer, offset);
+        }
+
         #endregion
     }
 }

--- a/SaintCoinach/Ex/DataReader.cs
+++ b/SaintCoinach/Ex/DataReader.cs
@@ -113,6 +113,8 @@ namespace SaintCoinach.Ex {
         /// <returns>Returns the value read from the given <c>row</c> and <c>column</c>.</returns>
         public abstract object Read(byte[] buffer, Column col, IDataRow row);
 
+        public abstract object Read(byte[] buffer, int offset);
+
         /// <summary>
         ///     Get the absolute offset in the EX data file of a column for a given row.
         /// </summary>

--- a/SaintCoinach/Ex/DataReaders/DelegateDataReader.cs
+++ b/SaintCoinach/Ex/DataReaders/DelegateDataReader.cs
@@ -83,5 +83,9 @@ namespace SaintCoinach.Ex.DataReaders {
             var offset = GetFieldOffset(col, row);
             return _Func(buffer, offset);
         }
+
+        public override object Read(byte[] buffer, int offset) {
+            return _Func(buffer, offset);
+        }
     }
 }

--- a/SaintCoinach/Ex/DataReaders/PackedBooleanDataReader.cs
+++ b/SaintCoinach/Ex/DataReaders/PackedBooleanDataReader.cs
@@ -65,6 +65,10 @@ namespace SaintCoinach.Ex.DataReaders {
             return (buffer[offset] & _Mask) != 0;
         }
 
+        public override object Read(byte[] buffer, int offset) {
+            return (buffer[offset] & _Mask) != 0;
+        }
+
         #endregion
     }
 }

--- a/SaintCoinach/Ex/DataReaders/StringDataReader.cs
+++ b/SaintCoinach/Ex/DataReaders/StringDataReader.cs
@@ -58,6 +58,10 @@ namespace SaintCoinach.Ex.DataReaders {
             return Text.XivStringDecoder.Default.Decode(binaryString);//.ToString();
         }
 
+        public override object Read(byte[] buffer, int offset) {
+            throw new NotSupportedException();
+        }
+
         #endregion
     }
 }

--- a/SaintCoinach/Ex/DataRowBase.cs
+++ b/SaintCoinach/Ex/DataRowBase.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SaintCoinach.Ex {
+    public abstract class DataRowBase : IDataRow {
+
+        #region Constructors
+
+        protected DataRowBase(IDataSheet sheet, int key, int offset) {
+            Sheet = sheet;
+            Key = key;
+            Offset = offset;
+        }
+
+        #endregion
+
+        public IDataSheet Sheet { get; private set; }
+        ISheet IRow.Sheet { get { return Sheet; } }
+        public int Key { get; private set; }
+        public int Offset { get; private set; }
+
+        #region IRow Members
+
+        public abstract object this[int columnIndex] { get; }
+        public abstract object GetRaw(int columnIndex);
+
+        #endregion
+    }
+}

--- a/SaintCoinach/Ex/ExCollection.cs
+++ b/SaintCoinach/Ex/ExCollection.cs
@@ -136,9 +136,15 @@ namespace SaintCoinach.Ex {
         }
 
         protected virtual ISheet CreateSheet(Header header) {
+            if (header.Variant == 2)
+                return CreateSheet<Variant1.DataRow>(header);
+            return CreateSheet<Variant2.DataRow>(header);
+        }
+
+        private ISheet CreateSheet<T>(Header header) where T : IDataRow {
             if (header.AvailableLanguages.Count() > 1)
-                return new MultiSheet<MultiRow, DataRow>(this, header);
-            return new DataSheet<DataRow>(this, header, header.AvailableLanguages.First());
+                return new MultiSheet<MultiRow, T>(this, header);
+            return new DataSheet<T>(this, header, header.AvailableLanguages.First());
         }
 
         #endregion

--- a/SaintCoinach/Ex/Header.cs
+++ b/SaintCoinach/Ex/Header.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -43,6 +44,7 @@ namespace SaintCoinach.Ex {
         public ExCollection Collection { get; private set; }
         public File File { get; private set; }
         public string Name { get; private set; }
+        public int Variant { get; private set; }
         public IEnumerable<Column> Columns { get { return _Columns; } }
         public IEnumerable<Range> DataFileRanges { get { return _DataFileRanges; } }
         public IEnumerable<Language> AvailableLanguages { get { return _AvailableLanguages; } }
@@ -84,6 +86,7 @@ namespace SaintCoinach.Ex {
             const uint Magic = 0x46485845; // EXHF
             const int MinimumLength = 0x2E;
             const int FixedSizeDataLengthOffset = 0x06;
+            const int VariantOffset = 0x10;
             const int DataOffset = 0x20;
 
             var buffer = File.GetData();
@@ -93,7 +96,11 @@ namespace SaintCoinach.Ex {
             if (OrderedBitConverter.ToUInt32(buffer, 0, false) != Magic)
                 throw new InvalidDataException("File not a EX header");
 
+
             FixedSizeDataLength = OrderedBitConverter.ToUInt16(buffer, FixedSizeDataLengthOffset, true);
+            Variant = OrderedBitConverter.ToUInt16(buffer, VariantOffset, true);
+            if (Variant != 1 && Variant != 2)
+                throw new NotSupportedException();
 
             var currentPosition = DataOffset;
             ReadColumns(buffer, ref currentPosition);

--- a/SaintCoinach/Ex/Relational/RelationalColumn.cs
+++ b/SaintCoinach/Ex/Relational/RelationalColumn.cs
@@ -43,6 +43,13 @@
             return def != null ? def.Convert(row, baseVal, Index) : baseVal;
         }
 
+        public override object Read(byte[] buffer, IDataRow row, int offset) {
+            var baseVal = base.Read(buffer, row, offset);
+
+            var def = Header.SheetDefinition;
+            return def != null ? def.Convert(row, baseVal, Index) : baseVal;
+        }
+
         #endregion
 
         public override string ToString() {

--- a/SaintCoinach/Ex/Relational/RelationalExCollection.cs
+++ b/SaintCoinach/Ex/Relational/RelationalExCollection.cs
@@ -35,9 +35,15 @@ namespace SaintCoinach.Ex.Relational {
 
         protected override ISheet CreateSheet(Header header) {
             var relHeader = (RelationalHeader)header;
+            if (relHeader.Variant == 2)
+                return CreateSheet<Variant2.RelationalDataRow>(relHeader);
+            return CreateSheet<Variant1.RelationalDataRow>(relHeader);
+        }
+
+        private ISheet CreateSheet<T>(RelationalHeader header) where T : IRelationalDataRow {
             if (header.AvailableLanguages.Count() > 1)
-                return new RelationalMultiSheet<RelationalMultiRow, RelationalDataRow>(this, relHeader);
-            return new RelationalDataSheet<RelationalDataRow>(this, relHeader, header.AvailableLanguages.First());
+                return new RelationalMultiSheet<RelationalMultiRow, T>(this, header);
+            return new RelationalDataSheet<T>(this, header, header.AvailableLanguages.First());
         }
 
         #endregion

--- a/SaintCoinach/Ex/Variant1/RelationalDataRow.cs
+++ b/SaintCoinach/Ex/Variant1/RelationalDataRow.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace SaintCoinach.Ex.Relational {
+namespace SaintCoinach.Ex.Variant1 {
+    using Relational;
+
     public class RelationalDataRow : DataRow, IRelationalDataRow {
         #region Fields
         private Dictionary<string, WeakReference<object>> _ValueReferences = new Dictionary<string, WeakReference<object>>();
-        #endregion
-
-        #region Constructors
-
-        public RelationalDataRow(IRelationalDataSheet sheet, int key, int offset) : base(sheet, key, offset) { }
-
         #endregion
 
         public new IRelationalDataSheet Sheet { get { return (IRelationalDataSheet)base.Sheet; } }
@@ -21,6 +20,12 @@ namespace SaintCoinach.Ex.Relational {
                        ? string.Format("{0}#{1}", Sheet.Header.Name, Key)
                        : string.Format("{0}", this[defCol.Index]);
         }
+
+        #region Constructors
+
+        public RelationalDataRow(IDataSheet sheet, int key, int offset) : base(sheet, key, offset) { }
+
+        #endregion
 
         #region IRelationalRow Members
 

--- a/SaintCoinach/Ex/Variant2/ColumnValues.cs
+++ b/SaintCoinach/Ex/Variant2/ColumnValues.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SaintCoinach.Ex.Variant2 {
+    internal class ColumnValues {
+        internal Dictionary<int, object> Values = new Dictionary<int, object>();
+        internal Dictionary<int, object> RawValues = new Dictionary<int, object>();
+
+        public Column Column { get; private set; }
+        public object this[int index] {
+            get { return Values[index]; }
+        }
+
+        internal ColumnValues(Column column) {
+            Column = column;
+        }
+    }
+}

--- a/SaintCoinach/Ex/Variant2/DataRow.cs
+++ b/SaintCoinach/Ex/Variant2/DataRow.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SaintCoinach.Ex.Variant2 {
+    public class DataRow : DataRowBase {
+        const int MetadataLength = 0x06;
+
+        private bool _IsRead;
+        private Dictionary<int, ColumnValues> _ColumnCache = new Dictionary<int, ColumnValues>();
+        private Dictionary<int, SubRow> _SubRows = new Dictionary<int, SubRow>();
+
+        public int Length { get; private set; }
+        public int SubRowCount { get; private set; }
+
+        public IEnumerable<int> SubRowKeys {
+            get {
+                if (!_IsRead) Read();
+                return _SubRows.Keys;
+            }
+        }
+        public IEnumerable<SubRow> SubRows {
+            get {
+                if (!_IsRead) Read();
+                return _SubRows.Values;
+            }
+        }
+
+        public SubRow GetSubRow(int key) {
+            if (!_IsRead) Read();
+            return _SubRows[key];
+        }
+
+        #region Constructors
+
+        public DataRow(IDataSheet sheet, int key, int offset) : base(sheet, key, offset + MetadataLength) {
+            var b = sheet.GetBuffer();
+            if (b.Length < offset + MetadataLength) throw new IndexOutOfRangeException();
+
+            Length = OrderedBitConverter.ToInt32(b, offset, true);
+            SubRowCount = OrderedBitConverter.ToInt16(b, offset + 4, true);
+        }
+
+        #endregion
+
+        protected virtual void Read() {
+            _ColumnCache.Clear();
+            _SubRows.Clear();
+
+            var h = Sheet.Header;
+            foreach (var c in h.Columns)
+                _ColumnCache.Add(c.Index, new ColumnValues(c));
+
+            var b = Sheet.GetBuffer();
+            var o = Offset;
+            for(var i = 0; i < SubRowCount; ++i) {
+                var key = OrderedBitConverter.ToInt16(b, o, true);
+
+                var r = new SubRow(this, key);
+                _SubRows.Add(key, r);
+
+                foreach(var c in _ColumnCache.Values) {
+                    var value = c.Column.Read(b, this, o + 2 + c.Column.Offset);
+                    r.Values.Add(c.Column.Index, value);
+                    c.Values.Add(key, value);
+
+                    var rawValue = c.Column.ReadRaw(b, this, o + 2 + c.Column.Offset);
+                    r.RawValues.Add(c.Column.Index, rawValue);
+                    c.RawValues.Add(key, rawValue);
+                }
+
+                o += 2 + h.FixedSizeDataLength;
+            }
+
+            _IsRead = true;
+        }
+        
+        public override object this[int column] {
+            get {
+                if (!_IsRead)
+                    Read();
+                return _ColumnCache[column].Values;
+            }
+        }
+
+        public override object GetRaw(int column) {
+            if (!_IsRead)
+                Read();
+            return _ColumnCache[column].RawValues;
+        }
+    }
+}

--- a/SaintCoinach/Ex/Variant2/RelationalDataRow.cs
+++ b/SaintCoinach/Ex/Variant2/RelationalDataRow.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SaintCoinach.Ex.Variant2 {
+    using Relational;
+
+    public class RelationalDataRow : DataRow, IRelationalDataRow {
+        public new IRelationalDataSheet Sheet { get { return (IRelationalDataSheet)base.Sheet; } }
+
+        public override string ToString() {
+            var defCol = Sheet.Header.DefaultColumn;
+            return defCol == null
+                       ? string.Format("{0}#{1}", Sheet.Header.Name, Key)
+                       : string.Format("{0}", this[defCol.Index]);
+        }
+
+        #region Constructors
+
+        public RelationalDataRow(IDataSheet sheet, int key, int offset) : base(sheet, key, offset) { }
+
+        #endregion
+
+        #region IRelationalRow Members
+
+        IRelationalSheet IRelationalRow.Sheet { get { return Sheet; } }
+
+        public object DefaultValue {
+            get {
+                var defCol = Sheet.Header.DefaultColumn;
+                return defCol == null ? null : this[defCol.Index];
+            }
+        }
+
+        public object this[string columnName] {
+            get {
+                var col = Sheet.Header.FindColumn(columnName);
+                if (col == null)
+                    throw new KeyNotFoundException();
+                return this[col.Index];
+            }
+        }
+
+        object IRelationalRow.GetRaw(string columnName) {
+            var column = Sheet.Header.FindColumn(columnName);
+            if (column == null)
+                throw new KeyNotFoundException();
+            return this.GetRaw(column.Index);
+        }
+
+        #endregion
+    }
+}

--- a/SaintCoinach/Ex/Variant2/SubRow.cs
+++ b/SaintCoinach/Ex/Variant2/SubRow.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SaintCoinach.Ex.Variant2 {
+    public class SubRow {
+        internal Dictionary<int, object> Values = new Dictionary<int, object>();
+        internal Dictionary<int, object> RawValues = new Dictionary<int, object>();
+
+        public int Key { get; private set; }
+        public IDataRow ParentRow { get; private set; }
+        public object this[int column] {
+            get { return Values[column]; }
+        }
+        public object GetRaw(int column) {
+            return RawValues[column];
+        }
+
+        internal SubRow(IDataRow parent, int key) {
+            ParentRow = parent;
+            Key = key;
+        }
+    }
+}

--- a/SaintCoinach/SaintCoinach.csproj
+++ b/SaintCoinach/SaintCoinach.csproj
@@ -80,6 +80,12 @@
     <Compile Include="Ex\DataSheet.Enumerator.cs" />
     <Compile Include="Ex\MultiSheet.Enumerator.cs" />
     <Compile Include="Ex\PartialDataSheet.Enumerator.cs" />
+    <Compile Include="Ex\Variant1\DataRow.cs" />
+    <Compile Include="Ex\Variant1\RelationalDataRow.cs" />
+    <Compile Include="Ex\Variant2\ColumnValues.cs" />
+    <Compile Include="Ex\Variant2\DataRow.cs" />
+    <Compile Include="Ex\Variant2\RelationalDataRow.cs" />
+    <Compile Include="Ex\Variant2\SubRow.cs" />
     <Compile Include="Xiv\ActionTransient.cs" />
     <Compile Include="Xiv\CompanionTransient.cs" />
     <Compile Include="Xiv\ContentFinderCondition.cs" />
@@ -421,9 +427,8 @@
     <Compile Include="Ex\Relational\RelationalMultiRow.cs" />
     <Compile Include="Ex\Relational\RelationalMultiSheet.cs" />
     <Compile Include="Ex\Relational\RelationalPartialDataSheet.cs" />
-    <Compile Include="Ex\Relational\RelationalDataRow.cs" />
     <Compile Include="Ex\Relational\RelationalDataSheet.cs" />
-    <Compile Include="Ex\DataRow.cs" />
+    <Compile Include="Ex\DataRowBase.cs" />
     <Compile Include="Ex\DataSheet.cs" />
     <Compile Include="Ex\Relational\Serialization\ExRelationEventEmitter.cs" />
     <Compile Include="Ex\Relational\Serialization\ExRelationSerializer.cs" />


### PR DESCRIPTION
Added support for a variant of .exd files containing multiple values per cell, cells in those files will return values as an IDictionary<int, object>.

As of now the following files use this variant:
- AnimaWeapon5SpiritTalk
- Behavior
- ClassJobResident
- Credit
- DeepDungeonMap5X
- GatheringItemPoint
- GCScripShopItem
- HousingMapMarkerInfo
- MapMarker
- MobHuntOrder
- QuestClassJobReward
- Resident
- TreasureSpot
- VaseSlot
- WeatherGroup
- ZoneSharedGroup
- ZoneTimeline
