### PR TITLE
Fixed some issues with XivStringDecoder

### DIFF
--- a/SaintCoinach/Text/DecodeExpressionType.cs
+++ b/SaintCoinach/Text/DecodeExpressionType.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 namespace SaintCoinach.Text {
     public enum DecodeExpressionType : byte {
         GreaterThanOrEqualTo = 0xE0,    // Followed by two variables
-        UnknownComparisonE1 = 0xE1,     // Followed by one variable
+        GreaterThan = 0xE1,             // Followed by one variable
         LessThanOrEqualTo = 0xE2,       // Followed by two variables
-        NotEqual = 0xE3,                // Followed by one variable
+        LessThan = 0xE3,                // Followed by one variable
         Equal = 0xE4,                   // Followed by two variables
-        UnknownComparisonE5 = 0xE5,     // Followed by two variables
+        NotEqual = 0xE5,                // TODO: Probably
 
         // TODO: I /think/ I got these right.
         IntegerParameter = 0xE8,        // Followed by one variable
@@ -27,7 +27,7 @@ namespace SaintCoinach.Text {
         Int24 = 0xF6,                   // Followed by a Int24
 
         Int24_SafeZero = 0xFA,          // Followed by a Int24, but 0xFF bytes set to 0 instead.
-        Int24_Unknown = 0xFD,           // Followed by a Int24, only used by <Time>?
+        Int24_Lsh8 = 0xFD,              // Followed by a Int24, and left-shifted by 8 bits
         Int32 = 0xFE,                   // Followed by a Int32
 
         Decode = 0xFF,                  // Followed by length (inlcuding length) and data

--- a/SaintCoinach/Text/DefaultEvaluationFunctionProvider.cs
+++ b/SaintCoinach/Text/DefaultEvaluationFunctionProvider.cs
@@ -218,10 +218,20 @@ namespace SaintCoinach.Text {
                         var iRight = ToInteger(evalRight);
                         return iLeft >= iRight;
                     }
+                case DecodeExpressionType.GreaterThan: {
+                        var iLeft = ToInteger(evalLeft);
+                        var iRight = ToInteger(evalRight);
+                        return iLeft > iRight;
+                    }
                 case DecodeExpressionType.LessThanOrEqualTo: {
                         var iLeft = ToInteger(evalLeft);
                         var iRight = ToInteger(evalRight);
                         return iLeft <= iRight;
+                    }
+                case DecodeExpressionType.LessThan: {
+                        var iLeft = ToInteger(evalLeft);
+                        var iRight = ToInteger(evalRight);
+                        return iLeft < iRight;
                     }
                 case DecodeExpressionType.Equal:
                     return ExpressionsEqual(evalLeft, evalRight);


### PR DESCRIPTION
- Now properly reads previously unknown Int24 format
- Fixed comparisons
- Changed how outputs of `If/IfEquals` tags are read, should now work properly in most cases (one observed case with incomplete output, but was incomplete before as well.)
