### PR TITLE
Update JobClass

### DIFF
--- a/SaintCoinach/ex.yaml
+++ b/SaintCoinach/ex.yaml
@@ -364,6 +364,9 @@
   Name: ChainBonus
 - DataDefinitions:
   - InnerDefinition: !!single_def
+      Name: Name
+    Index: 0
+  - InnerDefinition: !!single_def
       Name: Abbreviation
     Index: 1
   - InnerDefinition: !!single_def
@@ -377,7 +380,7 @@
         TargetSheet: ClassJob
     Index: 23
   - InnerDefinition: !!single_def
-      Name: Name
+      Name: Name(English)
     Index: 24
   - InnerDefinition: !!single_def
       Name: Item{StartingWeapon}


### PR DESCRIPTION
Name was originally offset 24, however this is English in all 4 languages. Offset 0 has thecorrect name in all 4 languages.