### PR TITLE
Added automated builds via AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+version: 'Build {build}'
+
+skip_tags: true
+
+image: Visual Studio 2017
+configuration: Release
+platform: Any CPU
+
+cache:
+  - packages -> **\packages.config
+
+before_build:
+- ps: >-
+    $env:GIT_HASH = $env:APPVEYOR_REPO_COMMIT.Substring(0, 7)
+    
+    ($env:APPVEYOR_REPO_NAME) >> VERSION
+    
+    ($env:APPVEYOR_REPO_BRANCH) >> VERSION
+    
+    ($env:GIT_HASH) >> VERSION
+    
+    ($env:APPVEYOR_BUILD_VERSION) >> VERSION
+    
+    ($env:APPVEYOR_REPO_COMMIT_TIMESTAMP) >> VERSION
+    
+- appveyor-retry nuget restore
+
+build:
+  project: SaintCoinach.sln
+  verbosity: minimal
+
+after_build:
+- cmd: >-
+    cp README.md VERSION .\Godbert\bin\Release
+    
+    7z a Godbert-%APPVEYOR_REPO_BRANCH%-b%APPVEYOR_BUILD_NUMBER%-%GIT_HASH%.zip .\Godbert\bin\Release\* -mx=7
+    
+    cp README.md VERSION .\SaintCoinach.Cmd\bin\Release
+    
+    7z a SaintCoinach.Cmd-%APPVEYOR_REPO_BRANCH%-b%APPVEYOR_BUILD_NUMBER%-%GIT_HASH%.zip .\SaintCoinach.Cmd\bin\Release\* -mx=7
+    
+
+artifacts:
+- path: Godbert-$(APPVEYOR_REPO_BRANCH)-b$(APPVEYOR_BUILD_NUMBER)-$(GIT_HASH).zip
+  name: Godbert
+- path: SaintCoinach.Cmd-$(APPVEYOR_REPO_BRANCH)-b$(APPVEYOR_BUILD_NUMBER)-$(GIT_HASH).zip
+  name: SaintCoinach.Cmd
+
+deploy:
+- provider: GitHub
+  release: $(APPVEYOR_BUILD_VERSION)
+  description: ""
+  artifact: Godbert,SaintCoinach.Cmd
+  auth_token:
+    secure: nJm0eDjrcfLhUCTsM7AiTp7GJi40mWXB8LPFRHek/uMqcvX2mdxxZ8cusuns5GAO


### PR DESCRIPTION
This pull requests adds automated builds of Saint Coinach stuff via AppVeyor.  The result is automatically packaged and uploaded to GitHub Releases with each commit.

## Why?

Automated builds would make `Godbert` and `SaintCoinach.Cmd` more accessible to non-technical users and generally keep an up to date version at the ready.

AppVeyor was chosen because it offers a Windows build environment needed by Saint Coinach, where popular alternatives like Travis CI only offer Mac and Linux.  Luckily, AppVeyor has similar syntax to Travis CI and is free for open source projects.

## How to use?

AppVeyor is configured via the `appveyor.yml` file.  Currently, it automatically builds on commit and pushes the zipped executable + README back to GitHub Releases for `Godbert` and `SaintCoinach.Cmd`.

Just keep committing as usual and it will magically work!

Edit the release on GitHub afterwards to add patch notes, if applicable.  Else the release description may default to a blank message or the latest commit message.

## What's left to do?

Automatic builds need to be enabled at AppVeyor and the `auth_token` needs to be set from a GitHub account with write access to the repo.

### Configuring AppVeyor

1. [Log in at AppVeyor](https://ci.appveyor.com) using your GitHub credentials.
2. Click `(+) New Project` in the top left, then `GitHub` > `Authorize GitHub` for public projects.
3. Back in AppVeyor, mouse over `SaintCoinach` and click `(+) Add` on the far right.

### Configuring `auth_token`

1. [Log in at AppVeyor](https://ci.appveyor.com) using your GitHub credentials.
2. On GitHub, [generate a new access token](https://github.com/settings/tokens):
    1. Click `Generate new token` in the top right.
    2. Name it `AppVeyor` and check `public_repo`.
    3. Copy the resulting token somewhere safe.
3. On AppVeyor, [encrypt the token](https://ci.appveyor.com/tools/encrypt) for safe use in the config file:
    1. Paste the previously generated token and click `Encrypt`.
    2. In `appveyor.yml`, set `auth_token: secure:` to the encrypted token from last step.  **DO NOT use the unencrypted token** here or bad things can happen to your repos!
    3. Commit and tag the change containing the updated auth token, then push.

From here on, AppVeyor will autonomously process each commit without further intervention.