### PR TITLE
option to view raw data in table view

### DIFF
--- a/Godbert/Controls/ColumnFactory.cs
+++ b/Godbert/Controls/ColumnFactory.cs
@@ -64,10 +64,12 @@ namespace Godbert.Controls {
             };
         }
 
-
+        public static bool ForceRaw;
         public static readonly System.Windows.Data.IValueConverter CellConverterInstance = new CellConverter();
 
         private class CellConverter : System.Windows.Data.IValueConverter {
+
+
 
             #region IValueConverter Members
 
@@ -77,6 +79,10 @@ namespace Godbert.Controls {
                     return null;
 
                 var i = System.Convert.ToInt32(parameter);
+
+                if (ForceRaw)
+                    return row.GetRaw(i);
+
                 return row[i] ?? row.GetRaw(i);
             }
 

--- a/Godbert/Controls/RawDataGrid.cs
+++ b/Godbert/Controls/RawDataGrid.cs
@@ -13,6 +13,8 @@ using SaintCoinach.Ex.Relational;
 using Godbert.ViewModels;
 using SaintCoinach.Xiv;
 using System.Collections;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 using SaintCoinach.Ex;
 
 namespace Godbert.Controls {
@@ -110,6 +112,22 @@ namespace Godbert.Controls {
         protected override void OnMouseDown(MouseButtonEventArgs e) {
             base.OnMouseDown(e);
 
+            if (e.RightButton == MouseButtonState.Pressed)
+            {
+                var cell = GetClickedHeader(e);
+                if (cell == null)
+                    return;
+
+                if (cell.Column is RawDataGridImageColumn ||
+                    cell.Column is RawDataGridTextColumn ||
+                    cell.Column is RawDataGridColorColumn)
+                {
+                    ColumnFactory.ForceRaw = !ColumnFactory.ForceRaw;
+                    Items.Refresh();
+                    e.Handled = true;
+                }
+            }
+
             if (e.MiddleButton == MouseButtonState.Pressed) {
                 var cell = GetClickedCell(e);
                 if (cell == null)
@@ -146,6 +164,21 @@ namespace Godbert.Controls {
 
                 dataViewModel.Bookmarks.Add(bookmark);
             }
+        }
+
+        private DataGridColumnHeader GetClickedHeader(MouseButtonEventArgs e)
+        {
+            DependencyObject dep = (DependencyObject)e.OriginalSource;
+
+            // iteratively traverse the visual tree
+            while ((dep != null) &&
+            !(dep is DataGridCell) &&
+            !(dep is DataGridColumnHeader))
+            {
+                dep = VisualTreeHelper.GetParent(dep);
+            }
+
+            return dep as DataGridColumnHeader;
         }
 
         protected override void OnMouseDoubleClick(MouseButtonEventArgs e) {

--- a/SaintCoinach.Cmd/Program.cs
+++ b/SaintCoinach.Cmd/Program.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Tharga.Toolkit.Console;
 using Tharga.Toolkit.Console.Command;
+using Tharga.Toolkit.Console.Command.Base;
 
 namespace SaintCoinach.Cmd {
     class ConsoleProgressReporter : IProgress<Ex.Relational.Update.UpdateProgress> {
@@ -62,16 +63,12 @@ namespace SaintCoinach.Cmd {
         }
 
         static void Setup(RootCommand rootCmd, ARealmReversed realm) {
-            rootCmd.RegisterCommand(new Commands.LanguageCommand(realm));
-            rootCmd.RegisterCommand(new Commands.RawCommand(realm));
-            rootCmd.RegisterCommand(new Commands.ImageCommand(realm));
-            rootCmd.RegisterCommand(new Commands.UiCommand(realm));
-            rootCmd.RegisterCommand(new Commands.MapCommand(realm));
-            rootCmd.RegisterCommand(new Commands.ExdCommand(realm));
-            rootCmd.RegisterCommand(new Commands.AllExdCommand(realm));
-            rootCmd.RegisterCommand(new Commands.RawExdCommand(realm));
-            rootCmd.RegisterCommand(new Commands.AllExdRawCommand(realm));
-            rootCmd.RegisterCommand(new Commands.BgmCommand(realm));
+            var assembly = typeof(Program).Assembly;
+            foreach (var t in assembly.GetTypes().Where(t => typeof(ActionCommandBase).IsAssignableFrom(t)))
+            {
+                var cons = t.GetConstructor(new[] { typeof(ARealmReversed) });
+                rootCmd.RegisterCommand((ActionCommandBase)cons.Invoke(new[] { realm }));
+            }
         }
 
         static string[] SearchForDataPaths() {


### PR DESCRIPTION
Add support to DataGrid to RightClick column headers to view the raw values for the (whole) table. 

This also includes a small change to the CMD command to use reflection to get available commands that can be loaded in. 