### PR TITLE
Improve consistency of column names

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -3136,7 +3136,7 @@
         },
         {
           "index": 2,
-          "name": "Level"
+          "name": "DifficultyLevel"
         },
         {
           "index": 4,

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -7278,7 +7278,7 @@
       "defaultColumn": "PlaceName",
       "definitions": [
         {
-          "name": "Level"
+          "name": "NodeLevel"
         },
         {
           "index": 2,

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -5254,7 +5254,7 @@
         },
         {
           "index": 1,
-          "name": "MinLevel"
+          "name": "ClassJobLevel"
         },
         {
           "index": 2,
@@ -5307,7 +5307,7 @@
                 }
               },
               {
-                "name": "MaxLevel"
+                "name": "ClassJobLevel{Max}"
               },
               {
                 "name": "Stars"

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -3063,7 +3063,7 @@
       "defaultColumn": "PlaceName",
       "definitions": [
         {
-          "name": "Level"
+          "name": "NodeLevel"
         },
         {
           "index": 1,
@@ -3328,7 +3328,7 @@
         },
         {
           "index": 1,
-          "name": "Level"
+          "name": "NodeLevel"
         },
         {
           "index": 2,

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -139,7 +139,7 @@
         },
         {
           "index": 11,
-          "name": "Level"
+          "name": "ClassJobLevel"
         },
         {
           "index": 12,
@@ -1047,7 +1047,7 @@
       "sheet": "BuddySkill",
       "definitions": [
         {
-          "name": "Level"
+          "name": "BuddyLevel"
         }
       ]
     },
@@ -1920,7 +1920,7 @@
         },
         {
           "index": 8,
-          "name": "Level"
+          "name": "ClassJobLevel"
         },
         {
           "index": 10,
@@ -2084,7 +2084,7 @@
         },
         {
           "index": 7,
-          "name": "Level"
+          "name": "ClassJobLevel"
         },
         {
           "index": 10,
@@ -2853,11 +2853,11 @@
       "definitions": [
         {
           "index": 2,
-          "name": "CLevel"
+          "name": "ClassJobLevel"
         },
         {
           "index": 3,
-          "name": "CLevel{Max}"
+          "name": "ClassJobLevel{Max}"
         },
         {
           "index": 4,
@@ -4074,7 +4074,7 @@
         },
         {
           "index": 3,
-          "name": "Level{Sync}"
+          "name": "ClassJobLevel{Sync}"
         },
         {
           "index": 4,
@@ -4764,7 +4764,7 @@
         },
         {
           "index": 5,
-          "name": "CLevel"
+          "name": "ClassJobLevel"
         },
         {
           "index": 9,
@@ -5832,7 +5832,7 @@
         },
         {
           "index": 4,
-          "name": "ClassLevel[0]"
+          "name": "ClassJobLevel[0]"
         },
         {
           "index": 5,
@@ -5848,7 +5848,7 @@
         },
         {
           "index": 8,
-          "name": "ClassLevel[1]"
+          "name": "ClassJobLevel[1]"
         },
         {
           "index": 9,
@@ -6475,7 +6475,7 @@
         },
         {
           "index": 36,
-          "name": "UnlockKey",
+          "name": "SecretRecipeBook",
           "converter": {
             "type": "link",
             "target": "SecretRecipeBook"
@@ -6524,7 +6524,7 @@
       "sheet": "RecipeLevelTable",
       "definitions": [
         {
-          "name": "CharacterLevel"
+          "name": "ClassJobLevel"
         },
         {
           "index": 1,
@@ -6829,7 +6829,7 @@
         },
         {
           "index": 2,
-          "name": "Level"
+          "name": "RetainerLevel"
         },
         {
           "index": 4,
@@ -8040,7 +8040,7 @@
       "isGenericReferenceTarget": true,
       "definitions": [
         {
-          "name": "LevelId",
+          "name": "Level",
           "converter": {
             "type": "link",
             "target": "Level"

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -3229,7 +3229,7 @@
       "sheet": "GatheringItemLevelConvertTable",
       "definitions": [
         {
-          "name": "Level"
+          "name": "ItemLevel"
         },
         {
           "index": 1,

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -3063,7 +3063,7 @@
       "defaultColumn": "PlaceName",
       "definitions": [
         {
-          "name": "NodeLevel"
+          "name": "GatheringLevel"
         },
         {
           "index": 1,
@@ -3136,7 +3136,7 @@
         },
         {
           "index": 2,
-          "name": "DifficultyLevel"
+          "name": "GatheringItemLevel"
         },
         {
           "index": 4,
@@ -3229,7 +3229,7 @@
       "sheet": "GatheringItemLevelConvertTable",
       "definitions": [
         {
-          "name": "ItemLevel"
+          "name": "GatheringItemLevel"
         },
         {
           "index": 1,
@@ -3328,7 +3328,7 @@
         },
         {
           "index": 1,
-          "name": "NodeLevel"
+          "name": "GatheringLevel"
         },
         {
           "index": 2,
@@ -7278,7 +7278,7 @@
       "defaultColumn": "PlaceName",
       "definitions": [
         {
-          "name": "NodeLevel"
+          "name": "GatheringLevel"
         },
         {
           "index": 2,


### PR DESCRIPTION
> PR created for discussion and continued work until it feels ready.

A majority of the `ex.json` file is very consistent and in excellent shape, this PR aims to meet a 100% shared param name for common names (eg: `ClassJobLevel` vs `Level`)

### Rules:

- Idealy, linked tables should be named the same unless it doesn't make sense to. eg:
  - Column: `MinionRace` links to `MinionRace` file. Makes sense being named the same
  - Column: `Behavior` links to `CompanionMove`. No one would say "what companion move type is that minion?" so the name doesn't make sense to be the same. `Behavior` is more appropriate.

### Recipes:

- `UnlockKey` > `SecretRecipeBook`, would this make more sense? Most columns that link to another field (eg Placename, or RecipeLevelTable etc) use the name of the table they link to vs a "custom name".

### Character Level / Class Job Level / "Level"

There can be areas of confusion when relating to the "Level", I think changing all params that do not read the "Level" CSV should be named more explicitly. Some examples:

- ClassJobLevel
- RetainerLevel
- ItemLevel

**Changes so far:**

- All "character" related levels changed to: `ClassJobLevel`

**Some to think about, I'm unsure on**

- `FishingSpot` and `FishParameter` both have a "Level" but unsure if this is class level? I don't do fishing!
- `GatheringItemLevelConvertTable` and `GatheringPointBase` both have a Level column.
- `MasterpieceSupplyDuty` has `MinLevel`, should this be `ClassJobLevel{Min}` ? (it also has a `MaxLevel` field)
- `SpearfishingNotebook` has a Level field, this a class level?