### PR TITLE
Fix crash on Chinese version

### DIFF
--- a/SaintCoinach/Ex/Header.cs
+++ b/SaintCoinach/Ex/Header.cs
@@ -21,7 +21,7 @@ namespace SaintCoinach.Ex {
             }, {
                 4, Language.French
             }, {
-                5, Language.Unsupported /*"chs"*/
+                5, Language.ChineseSimplified /*"chs"*/
             }, {
                 6, Language.Unsupported /*"cht"*/
             }, {

--- a/SaintCoinach/Ex/Language.cs
+++ b/SaintCoinach/Ex/Language.cs
@@ -11,7 +11,7 @@ namespace SaintCoinach.Ex {
         [Description("en")] English,
         [Description("de")] German,
         [Description("fr")] French,
-        //[Description("chs")] ChineseSimplified,
+        [Description("chs")] ChineseSimplified,
         //[Description("cht")] ChineseTraditional,
         //[Description("ko")] Korean,
 
@@ -34,7 +34,7 @@ namespace SaintCoinach.Ex {
                 yield return Language.English;
                 yield return Language.French;
                 yield return Language.German;
-                //yield return Language.ChineseSimplified;
+                yield return Language.ChineseSimplified;
                 //yield return Language.ChineseTraditional;
                 //yield return Language.Korean;
             }

--- a/SaintCoinach/Xiv/XivCollection.cs
+++ b/SaintCoinach/Xiv/XivCollection.cs
@@ -327,6 +327,10 @@ namespace SaintCoinach.Xiv {
 
             var allTypes = Assembly.GetExecutingAssembly().GetTypes();
 
+            //hack for chinese version
+            if (sheetName.EndsWith("_chs")) {
+                sheetName = sheetName.Substring(0, sheetName.Length - 4);
+            }
             var search = "Xiv." + sheetName.Replace('/', '.');
             var targetType = typeof(IXivRow);
             match = allTypes.FirstOrDefault(_ => _.FullName.EndsWith(search) && targetType.IsAssignableFrom(_));


### PR DESCRIPTION
~~Removes `_chs` sheet suffix that breaks `XivCollection.GetXivRowType`.~~

~~Godbert works well without modification.~~

Update: See Nov 18 post for final solution