### PR TITLE
Fix SaintCoinach type cast exception when only one language is available.

### DIFF
--- a/SaintCoinach/Ex/ExCollection.cs
+++ b/SaintCoinach/Ex/ExCollection.cs
@@ -143,7 +143,7 @@ namespace SaintCoinach.Ex {
         }
 
         private ISheet CreateSheet<T>(Header header) where T : IDataRow {
-            if (header.AvailableLanguages.Count() > 1)
+            if (header.AvailableLanguagesCount >= 1)
                 return new MultiSheet<MultiRow, T>(this, header);
             return new DataSheet<T>(this, header, header.AvailableLanguages.First());
         }

--- a/SaintCoinach/Ex/Header.cs
+++ b/SaintCoinach/Ex/Header.cs
@@ -23,9 +23,9 @@ namespace SaintCoinach.Ex {
             }, {
                 5, Language.ChineseSimplified /*"chs"*/
             }, {
-                6, Language.Unsupported /*"cht"*/
+                6, Language.ChineseTraditional /*"cht"*/
             }, {
-                7, Language.Unsupported /*"ko"*/
+                7, Language.Korean /*"ko"*/
             }
         };
 

--- a/SaintCoinach/Ex/Header.cs
+++ b/SaintCoinach/Ex/Header.cs
@@ -21,7 +21,7 @@ namespace SaintCoinach.Ex {
             }, {
                 4, Language.French
             }, {
-                5, Language.Unsupported /*"chs"*/
+                5, Language.ChineseSimplified /*"chs"*/
             }, {
                 6, Language.Unsupported /*"cht"*/
             }, {
@@ -49,6 +49,7 @@ namespace SaintCoinach.Ex {
         public int ColumnCount {  get { return _Columns.Length; } }
         public IEnumerable<Range> DataFileRanges { get { return _DataFileRanges; } }
         public IEnumerable<Language> AvailableLanguages { get { return _AvailableLanguages; } }
+        public int AvailableLanguagesCount { get { return _AvailableLanguages.Count(x => x != Language.None); } }
         public int FixedSizeDataLength { get; private set; }
 
         #endregion

--- a/SaintCoinach/Ex/Language.cs
+++ b/SaintCoinach/Ex/Language.cs
@@ -12,8 +12,8 @@ namespace SaintCoinach.Ex {
         [Description("de")] German,
         [Description("fr")] French,
         [Description("chs")] ChineseSimplified,
-        //[Description("cht")] ChineseTraditional,
-        //[Description("ko")] Korean,
+        [Description("cht")] ChineseTraditional,
+        [Description("ko")] Korean,
 
         [Description("?")] Unsupported
     }
@@ -35,8 +35,8 @@ namespace SaintCoinach.Ex {
                 yield return Language.French;
                 yield return Language.German;
                 yield return Language.ChineseSimplified;
-                //yield return Language.ChineseTraditional;
-                //yield return Language.Korean;
+                yield return Language.ChineseTraditional;
+                yield return Language.Korean;
             }
         }
 

--- a/SaintCoinach/Ex/Language.cs
+++ b/SaintCoinach/Ex/Language.cs
@@ -11,7 +11,7 @@ namespace SaintCoinach.Ex {
         [Description("en")] English,
         [Description("de")] German,
         [Description("fr")] French,
-        //[Description("chs")] ChineseSimplified,
+        [Description("chs")] ChineseSimplified,
         //[Description("cht")] ChineseTraditional,
         //[Description("ko")] Korean,
 
@@ -34,7 +34,7 @@ namespace SaintCoinach.Ex {
                 yield return Language.English;
                 yield return Language.French;
                 yield return Language.German;
-                //yield return Language.ChineseSimplified;
+                yield return Language.ChineseSimplified;
                 //yield return Language.ChineseTraditional;
                 //yield return Language.Korean;
             }

--- a/SaintCoinach/Ex/Relational/RelationalExCollection.cs
+++ b/SaintCoinach/Ex/Relational/RelationalExCollection.cs
@@ -41,7 +41,7 @@ namespace SaintCoinach.Ex.Relational {
         }
 
         private ISheet CreateSheet<T>(RelationalHeader header) where T : IRelationalDataRow {
-            if (header.AvailableLanguages.Count() > 1)
+            if (header.AvailableLanguagesCount >= 1)
                 return new RelationalMultiSheet<RelationalMultiRow, T>(this, header);
             return new RelationalDataSheet<T>(this, header, header.AvailableLanguages.First());
         }


### PR DESCRIPTION
In this situation, AvailableLanguages.Count() is 1, which is same count as Language.None.
The localized sheet is create as DataSheet insted of MultiSheet, then the language suffix(e.g. "item_chs") crashes the type casting.
Only tested on offical and chs client, so I leave cht and kor disabled.

Godbert's hardcoded to english on initialization, it will still crash in this situation.
