### PR TITLE
Update ex.json

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -7389,7 +7389,7 @@
       "defaultColumn": "0",
       "definitions": [
         {
-          "name": "0",
+          "name": "Primary",
           "converter": {
             "type": "link",
             "target": "VFX"
@@ -7397,7 +7397,7 @@
         },
         {
           "index": 1,
-          "name": "1",
+          "name": "Secondary",
           "converter": {
             "type": "link",
             "target": "VFX"

--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -7389,7 +7389,7 @@
       "defaultColumn": "0",
       "definitions": [
         {
-          "name": "Primary",
+          "name": "VFXNormal",
           "converter": {
             "type": "link",
             "target": "VFX"
@@ -7397,7 +7397,7 @@
         },
         {
           "index": 1,
-          "name": "Secondary",
+          "name": "VFXWalking",
           "converter": {
             "type": "link",
             "target": "VFX"


### PR DESCRIPTION
Updating these column names to prevent falsey returns when parsing the JSON doc with a non-strict typed language (eg: PHP or JavaScript), a typical issue would be:

```javascript
if (definitions[0].name) {
    // do something
}
```

*Column 0* would fail, *Column 1* would pass even though both exist and have links. There are ways around it by checking if `undefined` or `isset()` however I think it would be good practice to stick to names that are Alphanumeric and even better if they contain context.

If there is a better name that supplies a clearer context for this, fire below :)