### PR TITLE
[StatusLoopVFX] + [TerritoryType] Default Changes

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -10563,10 +10563,10 @@
     },
     {
       "sheet": "StatusLoopVFX",
-      "defaultColumn": "Location",
+      "defaultColumn": "VFX",
       "definitions": [
         {
-          "name": "Location",
+          "name": "VFX",
           "converter": {
             "type": "link",
             "target": "VFX"
@@ -10697,7 +10697,7 @@
     },
     {
       "sheet": "TerritoryType",
-      "defaultColumn": "Name",
+      "defaultColumn": "PlaceName",
       "definitions": [
         {
           "name": "Name"


### PR DESCRIPTION
[TerritoryType]
Changed to display a more readable result for example
"Limsa Lominsa Upper Decks" instead of "s1t1"
-Checked to ensure that it still works for every area, confirmed.

[StatusLoopVFX]
Name of the VFX made more sense to display, 'Location' i found too confusing with actual map locations etc.