### PR TITLE
[BuddyItem] Fix inconsistent column name

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -1851,7 +1851,7 @@
       "sheet": "BuddyItem",
       "definitions": [
         {
-          "name": "Name",
+          "name": "Item",
           "converter": {
             "type": "link",
             "target": "Item"


### PR DESCRIPTION
Linked content should be named by the content sheet they link to.