### PR TITLE
[GuildLeveAssigmentTalk] Removed for now

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -6416,15 +6416,6 @@
       ]
     },
     {
-      "sheet": "GuildleveAssignmentTalk",
-      "defaultColumn": "Name",
-      "definitions": [
-        {
-          "name": "Name"
-        }
-      ]
-    },
-    {
       "sheet": "GuildOrderGuide",
       "isGenericReferenceTarget": true,
       "definitions": []


### PR DESCRIPTION
Confusing regarding linking to GuildLeveAssignmentTalk from GuildLeveAssignment, ideally needs to reference the whole sheet and not a specific column.