### PR TITLE
emote col for whether an emote has a unique cancel emote

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -4171,6 +4171,10 @@
           }
         },
         {
+          "index": 15,
+          "name": "HasCancelEmote"
+        },
+        {
           "index": 18,
           "name": "TextCommand",
           "converter": {


### PR DESCRIPTION
seems to use emote index + 1 as the emote to use when exiting/cancelling the emote