### PR TITLE
Adding multi-passenger definition

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -9901,6 +9901,10 @@
           }
         },
         {
+          "index": 36,
+          "name": "ExtraSeats"
+        },
+        {
           "index": 37,
           "name": "MountAction",
           "converter": {


### PR DESCRIPTION
All the 2-seater mounts have a '1' in Column 36. Believe it's the number of extra seats, rather than "isMultiPassenger" or something similar. ExtraSeats is the best name I could come up with