### PR TITLE
[BaseParam] index 0 - order

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -1379,6 +1379,9 @@
       "defaultColumn": "Name",
       "definitions": [
         {
+          "name": "Order"
+        },
+        {
           "index": 1,
           "name": "Name"
         },


### PR DESCRIPTION
This displays in which order the stats (white numbers in pic) are put, not the words "strength" etc 

Normal : 
![nomod](https://user-images.githubusercontent.com/36118925/48701335-20cb4d00-ebe6-11e8-86b9-49d3da3f374d.png)

After altering: 
![yesmod](https://user-images.githubusercontent.com/36118925/48701347-2d4fa580-ebe6-11e8-9ddb-8399499819dc.png)

