### PR TITLE
Remove `HousingLayoutLimit` and `HousingItemCategory` links

### DIFF
--- a/SaintCoinach/ex.json
+++ b/SaintCoinach/ex.json
@@ -8226,28 +8226,12 @@
           "name": "ModelKey"
         },
         {
-          "index": 1,
-          "name": "HousingItemCategory",
-          "converter": {
-            "type": "link",
-            "target": "HousingItemCategory"
-          }
-        },
-        {
           "index": 2,
           "name": "UsageType"
         },
         {
           "index": 3,
           "name": "UsageParameter"
-        },
-        {
-          "index": 4,
-          "name": "HousingLayoutLimit",
-          "converter": {
-            "type": "link",
-            "target": "HousingLayoutLimit"
-          }
         },
         {
           "index": 5,
@@ -8535,28 +8519,12 @@
           "name": "ModelKey"
         },
         {
-          "index": 1,
-          "name": "HousingItemCategory",
-          "converter": {
-            "type": "link",
-            "target": "HousingItemCategory"
-          }
-        },
-        {
           "index": 2,
           "name": "UsageType"
         },
         {
           "index": 3,
           "name": "UsageParameter"
-        },
-        {
-          "index": 4,
-          "name": "HousingLayoutLimit",
-          "converter": {
-            "type": "link",
-            "target": "HousingLayoutLimit"
-          }
         },
         {
           "index": 5,


### PR DESCRIPTION
These two sheets do not exist in the current version of the game. Unsure if they've moved, removing as it breaks auto-linking.