### PR TITLE
Fixed JSON parse errors for stricter libraries.

### DIFF
--- a/SaintCoinach/Definitions/AnimationLOD.json
+++ b/SaintCoinach/Definitions/AnimationLOD.json
@@ -17,7 +17,7 @@
       "type": "repeat",
       "count": 8,
       "definition": {
-        "name": "AnimationEnable",
+        "name": "AnimationEnable"
       }
     }
   ]

--- a/SaintCoinach/Definitions/BNpcBase.json
+++ b/SaintCoinach/Definitions/BNpcBase.json
@@ -26,7 +26,7 @@
     },
     {
       "index": 3,
-      "name": "Rank",
+      "name": "Rank"
     },
     {
       "index": 4,
@@ -58,11 +58,11 @@
     },
     {
       "index": 8,
-      "name": "Special",
+      "name": "Special"
     },
     {
       "index": 9,
-      "name": "SEPack",
+      "name": "SEPack"
     },
     {
       "index": 11,
@@ -82,11 +82,11 @@
     },
     {
       "index": 14,
-      "name": "IsTargetLine",
+      "name": "IsTargetLine"
     },
     {
       "index": 15,
-      "name": "IsDisplayLevel",
+      "name": "IsDisplayLevel"
     }
   ]
 }

--- a/SaintCoinach/Definitions/BuddyItem.json
+++ b/SaintCoinach/Definitions/BuddyItem.json
@@ -10,15 +10,15 @@
     },
     {
       "index": 1,
-      "name": "UseField",
+      "name": "UseField"
     },
     {
       "index": 2,
-      "name": "UseTraining",
+      "name": "UseTraining"
     },
     {
       "index": 4,
-      "name": "Status",
+      "name": "Status"
     }
   ]
 }

--- a/SaintCoinach/Definitions/GatheringSubCategory.json
+++ b/SaintCoinach/Definitions/GatheringSubCategory.json
@@ -19,7 +19,7 @@
     },
     {
       "index": 3,
-      "name": "Division",
+      "name": "Division"
     },
     {
       "index": 4,

--- a/SaintCoinach/Definitions/PatchMark.json
+++ b/SaintCoinach/Definitions/PatchMark.json
@@ -2,7 +2,7 @@
   "sheet": "PatchMark",
   "definitions": [
     {
-      "name": "Category",
+      "name": "Category"
     },
     {
       "index": 1,

--- a/SaintCoinach/Definitions/Purify.json
+++ b/SaintCoinach/Definitions/Purify.json
@@ -10,7 +10,7 @@
     },
     {
       "index": 1,
-      "name": "Level",
+      "name": "Level"
     }
   ]
 }

--- a/SaintCoinach/Definitions/Recipe.json
+++ b/SaintCoinach/Definitions/Recipe.json
@@ -3,7 +3,7 @@
   "defaultColumn": "Item{Result}",
   "definitions": [
     {
-      "name": "Number",
+      "name": "Number"
     },
     {
       "index": 1,

--- a/SaintCoinach/Definitions/SpecialShop.json
+++ b/SaintCoinach/Definitions/SpecialShop.json
@@ -153,7 +153,7 @@
     },
     {
       "index": 1861,
-      "name": "UseCurrencyType",
+      "name": "UseCurrencyType"
     },
     {
       "index": 1862,


### PR DESCRIPTION
It doesn't appear this affects the Newtonsoft.Json library, but almost any other JSON parser library throws a parsing error for these trailing commas.