### PR TITLE
moved level{Max} to column 1438 since column 33 is unknown/not accurate

### DIFF
--- a/SaintCoinach/Definitions/Quest.json
+++ b/SaintCoinach/Definitions/Quest.json
@@ -163,10 +163,6 @@
       }
     },
     {
-      "index": 33,
-      "name": "Level{Max}"
-    },
-    {
       "index": 36,
       "name": "Mount{Required}",
       "converter": {
@@ -356,6 +352,10 @@
           }
         }
       }
+    },
+    {
+      "index": 1438,
+      "name": "Level{Max}"
     },
     {
       "index": 1439,


### PR DESCRIPTION
column 1438 has the maximum sync level for the different beast tribe daily quests (and every single shadowbringers sidequest) so it makes more sense for this to be the 'max' level one.