### PR TITLE
re-added Salvage file link to column 36 (broke Kupobot), but...

### DIFF
--- a/SaintCoinach/Definitions/Item.json
+++ b/SaintCoinach/Definitions/Item.json
@@ -241,7 +241,10 @@
     },
     {
       "index": 36,
-      "name": "Salvage"
+      "name": "Salvage",
+      "converter": {
+        "type": "link",
+        "target": "Salvage"
     },
     {
       "index": 37,

--- a/SaintCoinach/Definitions/Item.json
+++ b/SaintCoinach/Definitions/Item.json
@@ -243,8 +243,9 @@
       "index": 36,
       "name": "Salvage",
       "converter": {
-        "type": "link",
-        "target": "Salvage"
+      	"type": "link",
+      	"target": "Salvage"
+      }
     },
     {
       "index": 37,


### PR DESCRIPTION
the 'optimalskill' column in Salvage.exh is not the actual skill level anymore. It's ItemLevel. Its unknown what the 'optimalskill' column actually does, but it still does have an effect on whether an item can be desynth'd or not. It's just not the actual skill level anymore...