### PR TITLE
Add more chinese and korean support for godbert

### DIFF
--- a/Godbert/MainWindow.xaml
+++ b/Godbert/MainWindow.xaml
@@ -27,6 +27,14 @@
                           IsChecked="{Binding Path=IsFrench, Mode=OneWay}"
                           Command="{Binding Path=LanguageCommand}"
                           CommandParameter="{x:Static ex:Language.French}"  />
+                <MenuItem Header="ChineseSimplified"
+                          IsChecked="{Binding Path=IsChineseSimplified, Mode=OneWay}"
+                          Command="{Binding Path=LanguageCommand}"
+                          CommandParameter="{x:Static ex:Language.ChineseSimplified}"  />
+                <MenuItem Header="Korean"
+                          IsChecked="{Binding Path=IsKorean, Mode=OneWay}"
+                          Command="{Binding Path=LanguageCommand}"
+                          CommandParameter="{x:Static ex:Language.Korean}"  />
             </MenuItem>
             <MenuItem Header="Various">
                 <MenuItem Header="New Window"

--- a/Godbert/ViewModels/MainViewModel.cs
+++ b/Godbert/ViewModels/MainViewModel.cs
@@ -28,6 +28,8 @@ namespace Godbert.ViewModels {
         public bool IsJapanese { get { return Realm.GameData.ActiveLanguage == SaintCoinach.Ex.Language.Japanese; } }
         public bool IsFrench { get { return Realm.GameData.ActiveLanguage == SaintCoinach.Ex.Language.French; } }
         public bool IsGerman { get { return Realm.GameData.ActiveLanguage == SaintCoinach.Ex.Language.German; } }
+        public bool IsChineseSimplified { get { return Realm.GameData.ActiveLanguage == SaintCoinach.Ex.Language.ChineseSimplified; } }
+        public bool IsKorean { get { return Realm.GameData.ActiveLanguage == SaintCoinach.Ex.Language.Korean; } }
 
         public bool SortByOffsets { get { return Settings.Default.SortByOffsets;} }
         public bool ShowOffsets { get { return Settings.Default.ShowOffsets; } }
@@ -41,8 +43,26 @@ namespace Godbert.ViewModels {
         public MainViewModel() {
             if (!App.IsValidGamePath(Properties.Settings.Default.GamePath))
                 return;
-            var realm = new ARealmReversed(Properties.Settings.Default.GamePath, SaintCoinach.Ex.Language.English);
-            Initialize(realm);
+
+            var languages = new[] { SaintCoinach.Ex.Language.English, SaintCoinach.Ex.Language.ChineseSimplified, SaintCoinach.Ex.Language.Korean };
+            NotSupportedException lastException = null;
+
+            foreach (var language in languages) {
+                try {
+                    var realm = new ARealmReversed(Properties.Settings.Default.GamePath, language);
+                    Initialize(realm);
+                    lastException = null;
+                    break;
+                }
+                catch (NotSupportedException e) {
+                    lastException = e;
+                    continue;
+                }
+            }
+
+            if (lastException != null) {
+                throw new AggregateException(new[] { lastException });
+            }
         }
 
         public MainViewModel(ARealmReversed realm) {
@@ -83,6 +103,8 @@ namespace Godbert.ViewModels {
             OnPropertyChanged(() => IsJapanese);
             OnPropertyChanged(() => IsGerman);
             OnPropertyChanged(() => IsFrench);
+            OnPropertyChanged(() => IsChineseSimplified);
+            OnPropertyChanged(() => IsKorean);
 
             Equipment.Refresh();
             Territories.Refresh();


### PR DESCRIPTION
Hi,

Thanks for building SaintCoinach and Godbert!

When using Godbert, we chinese players will get a crash because Chinese client doesn't have English resources but Godbert init itself using English language by default. I think Korean client has the same issue too.

This pull request changed this, trying to use english, chinese and korean language to init realm, and add menu items allow users to switch to chinese and korean language (although it won't work when swithing from chinese to another language, or from any language to chinese, because of sqpack limits).

With this patch, we chinese players can use Godbert for datamining without crash or modification. This will help us a lot. If there are any issues or changes required, please let me know and I'm glad to fix it.

Thanks again!