### PR TITLE
Add new order & acquisition columns to TripleTriadCardResident

### DIFF
--- a/SaintCoinach/Definitions/TripleTriadCardResident.json
+++ b/SaintCoinach/Definitions/TripleTriadCardResident.json
@@ -50,6 +50,130 @@
       "name": "UIPriority"
     },
     {
+      "index": 11,
+      "name": "Unknown[5-4]"
+    },
+    {
+      "index": 12,
+      "name": "AcquisitionType"
+    },
+    {
+      "index": 13,
+      "name": "Acquisition",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 2
+            },
+            "sheet": "ContentFinderCondition"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 3
+            },
+            "sheet": "ContentFinderCondition"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 4
+            },
+            "sheet": "Fate"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 5
+            },
+            "sheet": "Fate"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 6
+            },
+            "sheet": "ENpcResident"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 8
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 9
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 10
+            },
+            "sheet": "ENpcResident"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 11
+            },
+            "sheet": "Achievement"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 12
+            },
+            "sheet": "ContentFinderCondition"
+          }
+        ]
+      }
+    },
+    {
+      "index": 14,
+      "name": "Location",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 4
+            },
+            "sheet": "TerritoryType"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 5
+            },
+            "sheet": "TerritoryType"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 6
+            },
+            "sheet": "Level"
+          },
+          {
+            "when": {
+              "key": "AcquisitionType",
+              "value": 10
+            },
+            "sheet": "Level"
+          }
+        ]
+      }
+    },
+    {
       "index": 15,
       "name": "Quest",
       "converter": {

--- a/SaintCoinach/Definitions/TripleTriadCardResident.json
+++ b/SaintCoinach/Definitions/TripleTriadCardResident.json
@@ -43,11 +43,11 @@
     },
     {
       "index": 9,
-      "type": "repeat",
-      "count": 6,
-      "definition": {
-        "name": "Unknown[5-4]"
-      }
+      "name": "Order"
+    },
+    {
+      "index": 10,
+      "name": "UIPriority"
     },
     {
       "index": 15,


### PR DESCRIPTION
Adds order and acquisition columns to TripleTriadCardResident. Thanks to @IcarusTwine for the acquisition columns!

#### Usage Notes
* Cards are now sorted in-game by UIPriority > Order
* Cards with a UIPriority of 5 are classified as "Ex" cards and have their own page at the end of the card list