### PR TITLE
Add ActionIndirection.ClassJob definition

### DIFF
--- a/SaintCoinach/Definitions/ActionIndirection.json
+++ b/SaintCoinach/Definitions/ActionIndirection.json
@@ -8,6 +8,14 @@
         "type": "link",
         "target": "Action"
       }
+    },
+    {
+      "index": 1,
+      "name": "ClassJob",
+      "converter": {
+        "type": "link",
+        "target": "ClassJob"
+      }
     }
   ]
 }


### PR DESCRIPTION
Title. This table seems to be used by the "Actions & Traits" window to override action/job links. For... some reason.