### PR TITLE
Improve PvPActionSort linking

### DIFF
--- a/SaintCoinach/Definitions/ClassJob.json
+++ b/SaintCoinach/Definitions/ClassJob.json
@@ -66,6 +66,10 @@
       "name": "Modifier{Piety}"
     },
     {
+      "index": 24,
+      "name": "PvPActionSortRow"
+    },
+    {
       "index": 26,
       "name": "ClassJob{Parent}",
       "converter": {

--- a/SaintCoinach/Definitions/PvPActionSort.json
+++ b/SaintCoinach/Definitions/PvPActionSort.json
@@ -3,14 +3,29 @@
   "defaultColumn": "Name",
   "definitions": [
     {
-      "name": "Name"
+      "name": "Action{Type}",
     },
     {
       "index": 1,
       "name": "Action",
       "converter": {
-        "type": "link",
-        "target": "Action"
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "Action{Type}",
+              "value": 1
+            },
+            "sheet": "Action"
+          },
+          {
+            "when": {
+              "key": "Action{Type}",
+              "value": 2
+            },
+            "sheet": "ActionComboRoute"
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Probably a change they made with the new pvp system. Name column is now a discriminator for the table they link to.

Should match up with UI now:
![image](https://user-images.githubusercontent.com/534235/110301850-b22b8b00-804c-11eb-99cd-0cba190145e4.png)

Also noticed that there was an unnamed column in ClassJob that links to the _primary_ Row ID in `PvPActionSort`. I've _not_ linked that, as it's a sheet with subrows, and all subrows for the primary job row are valid data for the link. Not sure I want to implement that handling :meowlul: