### PR TITLE
Add Link column to MYCWarResultNotebook

### DIFF
--- a/SaintCoinach/Definitions/MYCWarResultNotebook.json
+++ b/SaintCoinach/Definitions/MYCWarResultNotebook.json
@@ -6,6 +6,10 @@
       "name": "Number"
     },
     {
+      "index": 2,
+      "name": "Link"
+    },
+    {
       "index": 3,
       "name": "Quest",
       "converter": {


### PR DESCRIPTION
For field records with `Link > 0`, records with the same Link value are linked together as Page 1/2.